### PR TITLE
Integrate partially lido/songkick gigs sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,30 +12,40 @@ Currently supporting getting jazz concerts from Songkick in Berlin.
 ```elixir
 iex> Gigex.get() |> Enum.take(5)
 [
-  %{
-    name: "Led Zeppelin",
-    date: "2022-12-10",
-    location: "SO36"
-  },
-  %{
-    name: "The Cure",
-    date: "2022-12-09",
-    location: "Metropol"
-  },
-  %{
-    name: "The all seeing I",
-    date: "2022-12-12",
-    location: "Earthsea"
-  },
-  %{
-    name: "Kokoroko",
-    date: "2022-12-14",
-    location: "Tangeri"
-  },
-  %{
-    name: "Dave Brubeck",
-    date: "2022-12-15",
-    location: "Blue Note"
-  }
+   %{
+     name: "Led Zeppelin",
+     date: "2022-12-10",
+     dotw: "Thursday",
+     location: "SO36",
+     datasource: "lido"
+   },
+   %{
+     name: "The Cure",
+     date: "2022-12-09",
+     dotw: "Friday",
+     location: "Metropol",
+     datasource: "songkick"
+   },
+   %{
+     name: "The all seeing I",
+     date: "2022-12-12",
+     dotw: "Sunday",
+     location: "Earthsea",
+     datasource: "lido"
+   },
+   %{
+     name: "Kokoroko",
+     date: "2022-12-14",
+     dotw: "Wednesday",
+     location: "Tangeri",
+     datasource: "songkick"
+   },
+   %{
+     name: "Dave Brubeck",
+     date: "2022-12-15,
+     dotw: "Saturday",
+     location: "Blue Note"
+     datasource: "songkick"
+   }
 ]
 ```

--- a/lib/gigex.ex
+++ b/lib/gigex.ex
@@ -3,95 +3,54 @@ defmodule Gigex do
   Gigex 🎸
 
   A scraper for gigs.
-
-  ## Example
-
-      iex> Gigex.get()
-      [
-        %{
-          name: "The Cure",
-          date: "2022-12-09",
-          location: "Metropol"
-        },
-        %{
-          name: "Led Zeppelin",
-          date: "2022-12-10",
-          location: "SO36"
-        }
-      ]
   """
 
-  @spec get(url :: String.t()) :: concerts :: list()
   @doc """
-  Get the latest jazz gigs from Songkick in Berlin
+  Get the latest gigs from Songkick in Berlin
 
   ## Example
 
-      iex> Gigex.get() |> Enum.take(5)
+      iex> Gigex.gigs() |> Enum.take(5)
       [
         %{
           name: "Led Zeppelin",
           date: "2022-12-10",
-          location: "SO36"
+          dotw: "Thursday",
+          location: "SO36",
+          datasource: "lido"
         },
         %{
           name: "The Cure",
           date: "2022-12-09",
-          location: "Metropol"
+          dotw: "Friday",
+          location: "Metropol",
+          datasource: "songkick"
         },
         %{
           name: "The all seeing I",
           date: "2022-12-12",
-          location: "Earthsea"
+          dotw: "Sunday",
+          location: "Earthsea",
+          datasource: "lido"
         },
         %{
           name: "Kokoroko",
           date: "2022-12-14",
-          location: "Tangeri"
+          dotw: "Wednesday",
+          location: "Tangeri",
+          datasource: "songkick"
         },
         %{
           name: "Dave Brubeck",
           date: "2022-12-15,
+          dotw: "Saturday",
           location: "Blue Note"
+          datasource: "songkick"
         }
       ]
   """
-  def get(url \\ "https://www.songkick.com/metro-areas/28443-germany-berlin/genre/jazz") do
-    html =
-      HTTPoison.get!(url,
-        user_agent: "Gigex (Windows x64)",
-        timeout: 10_000
-      ).body
-
-    html
-    |> Floki.parse_document!()
-    |> Floki.find(".event-listings-element")
-    |> Enum.map(fn event ->
-      %{
-        name: extract_name(event),
-        date: extract_date_from_event(event),
-        location: extract_location(event)
-      }
-    end)
-  end
-
-  defp extract_date_from_event(event) do
-    event
-    |> Floki.attribute("title")
-    |> Floki.text()
-  end
-
-  defp extract_location(event) do
-    event
-    |> Floki.find(".location")
-    |> Floki.text()
-    |> String.trim()
-    |> String.replace(~r/[\n|\s]+/, " ")
-  end
-
-  defp extract_name(event) do
-    event
-    |> Floki.find(".artists")
-    |> Floki.text()
+  @spec gigs(site :: :all | :songkick | :lido) :: concerts :: list()
+  def gigs(site \\ :all) do
+    Gigex.Scraper.run_for(site)
   end
 end

--- a/lib/scraper.ex
+++ b/lib/scraper.ex
@@ -1,0 +1,15 @@
+defmodule Gigex.Scraper do
+  alias __MODULE__
+
+  @spec run_for(site :: atom()) :: concert :: list()
+  def run_for(:all) do
+    Enum.sort_by(
+      Scraper.Songkick.get() ++ Scraper.Lido.get(),
+      &Date.from_iso8601!(&1.date),
+      Date
+    )
+  end
+
+  def run_for(:songkick), do: Scraper.Songkick.get()
+  def run_for(:lido), do: Scraper.Lido.get()
+end

--- a/lib/scraper/lido.ex
+++ b/lib/scraper/lido.ex
@@ -1,0 +1,98 @@
+defmodule Gigex.Scraper.Lido do
+  @moduledoc """
+  Scraper for Lido
+
+  Lido is a dance club in Berlin, Germany
+  It hosts various different concerts, partys and events.
+  Website url: https://www.lido-berlin.de
+  """
+
+  @lido_url "https://www.lido-berlin.de"
+  @location_name "Lido"
+
+  @short_days_to_human_days %{
+    "Mo" => "Monday",
+    "Tu" => "Tuesday",
+    "We" => "Wednesday",
+    "Th" => "Thursday",
+    "Fr" => "Friday",
+    "Sa" => "Saturday",
+    "Su" => "Sunday"
+  }
+  @default_entries_limit 10
+
+  def get(opts \\ []) do
+    limit = Keyword.get(opts, :limit, @default_entries_limit)
+
+    html =
+      HTTPoison.get!(@lido_url,
+        user_agent: "Gigex (Windows x64)",
+        timeout: 10_000
+      ).body
+
+    html
+    |> Floki.parse_document!()
+    |> Floki.find(".event-ticket")
+    |> Enum.reduce_while(
+      {[], 0},
+      fn
+        _event, {entries, ^limit} ->
+          {:halt, entries}
+
+        event, {entries, acc} ->
+          entry = %{
+            name: extract_name(event),
+            date: extract_date(event),
+            location: @location_name,
+            dotw: extract_day_of_the_week(event),
+            # start_event: extract_entrance_hour(event),
+            # end_event: "unknown",
+            datasource: "lido"
+          }
+
+          {:cont, {[entry | entries], acc + 1}}
+      end
+    )
+  end
+
+  # NOTE: "data-realdate" it's in this format "2022-12-17 23:30:00 +0100"
+  # We are interested only in the first part (i.e. 2022-12-17)
+  defp extract_date(event) do
+    [date_time] = Floki.attribute(event, "data-realdate")
+
+    date_time
+    |> String.split()
+    |> hd()
+  end
+
+  defp extract_name(event) do
+    event
+    |> Floki.find(".event-ticket__content__title")
+    |> Floki.text()
+  end
+
+  # Extract the day in short form (i.e. Th) and expand it to a human readable
+  # day (i.e. Friday)
+  defp extract_day_of_the_week(event) do
+    event
+    |> Floki.find(".event-ticket__meta__day")
+    |> Floki.text()
+    |> then(fn short_day ->
+      Map.get(@short_days_to_human_days, short_day, short_day)
+    end)
+  end
+
+  # It returns the first entrance hour of the list, when the doors of the place
+  # are open.
+  # The second hour, usually matches with the open doors, since it's the start
+  # of the event.
+  # We ignore it for now since it's rare to have doors open not matching with
+  # the start of the event.
+  # defp extract_entrance_hour(event) do
+  #   event
+  #   |> Floki.children()
+  #   |> Floki.find(".event-ticket__meta__times__time__value")
+  #   |> hd()
+  #   |> Floki.text()
+  # end
+end

--- a/lib/scraper/songkick.ex
+++ b/lib/scraper/songkick.ex
@@ -1,0 +1,109 @@
+defmodule Gigex.Scraper.Songkick do
+  @moduledoc """
+  Scraper for songkick
+
+  Songkick hosts concerts and festivals from all over the world.
+  This scraper covers all the concerts and festivals in the Berliner area.
+
+  NOTE: For the moment the list of events is very for each day.
+  You could have a flood of events on the terminal.
+  """
+
+  @songkick "https://www.songkick.com"
+  @songkick_berlin_url "#{@songkick}/metro-areas/28443-germany-berlin/"
+  @default_entries_limit 10
+
+  def get(opts \\ []) do
+    limit = Keyword.get(opts, :limit, @default_entries_limit)
+
+    @songkick_berlin_url
+    |> http_get()
+    |> Floki.parse_document!()
+    |> Floki.find(".event-listings-element")
+    |> Enum.reduce_while(
+      {[], 0},
+      fn
+        _event, {entries, ^limit} ->
+          {:halt, Enum.reverse(entries)}
+
+        event, {entries, acc} ->
+          entry = %{
+            name: extract_name(event),
+            date: extract_date_from_event(event),
+            location: extract_location(event),
+            dotw: extract_day_of_the_week(event),
+            # event_details: extract_event_details(event),
+            datasource: "songkick"
+          }
+
+          {:cont, {[entry | entries], acc + 1}}
+      end
+    )
+  end
+
+  # normalize()?
+
+  defp extract_date_from_event(event) do
+    datetime =
+      event
+      |> Floki.children()
+      |> Floki.attribute("datetime")
+      |> Floki.text()
+
+    case DateTime.from_iso8601(datetime) do
+      {:ok, datetime, _} ->
+        datetime
+        |> DateTime.to_date()
+        |> to_string()
+
+      _ ->
+        datetime
+    end
+  end
+
+  defp extract_location(event) do
+    event
+    |> Floki.find(".location")
+    |> Floki.text()
+    |> String.trim()
+    |> String.replace(~r/[\n|\s]+/, " ")
+  end
+
+  defp extract_name(event) do
+    event
+    |> Floki.find(".artists")
+    |> Floki.text()
+  end
+
+  defp extract_day_of_the_week(event) do
+    [human_date] = Floki.attribute(event, "title")
+
+    human_date
+    |> String.split()
+    |> hd()
+  end
+
+  # defp extract_event_details(event) do
+  #   event_detail_url =
+  #     event
+  #     |> Floki.find(".event-link")
+  #     |> Floki.attribute("href")
+  #     |> hd()
+
+  #   # NOTE: Find out how to not hit too hard the website ;)
+  #   "#{@songkick}/#{event_detail_url}"
+  #   |> http_get()
+  #   |> Floki.parse_document!()
+  #   |> Floki.find(".additional-details-container")
+  #   |> Floki.text()
+  # end
+
+  def http_get(url) do
+    :timer.sleep(200)
+
+    HTTPoison.get!(url,
+      user_agent: "Gigex (Windows x64)",
+      timeout: 10_000
+    ).body
+  end
+end


### PR DESCRIPTION
Integrates https://www.lido-berlin.de and https://www.songkick.com/metro-areas/28443-germany-berlin
Now gigex starts to get shape to host other concert scrapers