### PR TITLE
Add :infos for event details to the results

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ iex> Gigex.get() |> Enum.take(5)
      dotw: "Thursday",
      link: "https://www.lido-berlin.de/events/2022-12-10-led-zeppelin---so36",
      location: "SO36",
+     infos: "15.00 € Abendkasse, 13.00 € Vorverkauf+ Geb , 11.00 € Early Bird+ Geb",
      datasource: "lido"
    },
    %{
@@ -26,6 +27,7 @@ iex> Gigex.get() |> Enum.take(5)
      dotw: "Friday",
      link: "https://www.lido-berlin.de/events/2022-12-09-the-cure---metropol",
      location: "Metropol",
+     infos: "15.00 € Abendkasse, 9.00 € Vorverkauf+ Geb , 7.00 € Early Bird+ Geb"
      datasource: "songkick"
    },
    %{
@@ -34,6 +36,7 @@ iex> Gigex.get() |> Enum.take(5)
      dotw: "Sunday",
      link: "https://www.lido-berlin.de/events/2022-12-12-the-all-seeing-i---earthsea",
      location: "Earthsea",
+     infos: "",
      datasource: "lido"
    },
    %{
@@ -42,6 +45,7 @@ iex> Gigex.get() |> Enum.take(5)
      dotw: "Wednesday",
      link: "https://www.lido-berlin.de/events/2022-12-14-kokokoko---tangeri",
      location: "Tangeri",
+     infos: "Price: €51.00 – €72.00\n      Doors open: 20:00",
      datasource: "songkick"
    },
    %{
@@ -50,6 +54,7 @@ iex> Gigex.get() |> Enum.take(5)
      dotw: "Saturday",
      link: "https://www.lido-berlin.de/events/2022-12-15-dave-brubeck---blue-note",
      location: "Blue Note"
+     infos: "Price: €25.00 – €32.50\n      Doors open: 20:00",
      datasource: "songkick"
    }
 ]

--- a/lib/gigex.ex
+++ b/lib/gigex.ex
@@ -18,6 +18,7 @@ defmodule Gigex do
           dotw: "Thursday",
           link: "https://www.lido-berlin.de/events/2022-12-10-led-zeppelin---so36",
           location: "SO36",
+          infos: "15.00 € Abendkasse, 13.00 € Vorverkauf+ Geb , 11.00 € Early Bird+ Geb",
           datasource: "lido"
         },
         %{
@@ -25,6 +26,7 @@ defmodule Gigex do
           date: "2022-12-09",
           dotw: "Friday",
           link: "https://www.lido-berlin.de/events/2022-12-09-the-cure---metropol",
+          infos: "15.00 € Abendkasse, 9.00 € Vorverkauf+ Geb , 7.00 € Early Bird+ Geb"
           location: "Metropol",
           datasource: "songkick"
         },
@@ -34,6 +36,7 @@ defmodule Gigex do
           dotw: "Sunday",
           link: "https://www.lido-berlin.de/events/2022-12-12-the-all-seeing-i---earthsea",
           location: "Earthsea",
+          infos: "",
           datasource: "lido"
         },
         %{
@@ -42,6 +45,7 @@ defmodule Gigex do
           dotw: "Wednesday",
           link: "https://www.lido-berlin.de/events/2022-12-14-kokokoko---tangeri",
           location: "Tangeri",
+          infos: "Price: €51.00 – €72.00\n      Doors open: 20:00",
           datasource: "songkick"
         },
         %{
@@ -50,6 +54,7 @@ defmodule Gigex do
           dotw: "Saturday",
           link: "https://www.lido-berlin.de/events/2022-12-15-dave-brubeck---blue-note",
           location: "Blue Note"
+          infos: "Price: €25.00 – €32.50\n      Doors open: 20:00",
           datasource: "songkick"
         }
       ]

--- a/lib/scraper/songkick.ex
+++ b/lib/scraper/songkick.ex
@@ -33,7 +33,7 @@ defmodule Gigex.Scraper.Songkick do
             location: extract_location(event),
             dotw: extract_day_of_the_week(event),
             link: extract_event_link(event),
-            # event_details: extract_event_details(event),
+            infos: extract_event_infos(event),
             datasource: "songkick"
           }
 
@@ -94,20 +94,20 @@ defmodule Gigex.Scraper.Songkick do
     "#{@songkick}#{link}"
   end
 
-  # defp extract_event_details(event) do
-  #   event_detail_url =
-  #     event
-  #     |> Floki.find(".event-link")
-  #     |> Floki.attribute("href")
-  #     |> hd()
+  defp extract_event_infos(event) do
+    event_link = extract_event_link(event)
 
-  #   # NOTE: Find out how to not hit too hard the website ;)
-  #   "#{@songkick}/#{event_detail_url}"
-  #   |> http_get()
-  #   |> Floki.parse_document!()
-  #   |> Floki.find(".additional-details-container")
-  #   |> Floki.text()
-  # end
+    # NOTE: Find out how to not hit too hard the website ;)
+    # Cache?
+    # For the moment `http_get/1` has a :timer.sleep of 200ms
+    event_link
+    |> http_get()
+    |> Floki.parse_document!()
+    |> Floki.find(".additional-details-container")
+    |> Floki.text()
+    # Trim surrounding blank space, `\n`, `\t`, etc.
+    |> String.trim()
+  end
 
   def http_get(url) do
     :timer.sleep(200)


### PR DESCRIPTION
Add `infos` for the event.
Usually they are hand written in a text field, so `infos` it's kinda free form text.