### PR TITLE
Add cache with content cleanup

### DIFF
--- a/lib/application.ex
+++ b/lib/application.ex
@@ -1,0 +1,12 @@
+defmodule Gigex.Application do
+  @moduledoc false
+
+  use Application
+
+  def start(_type, _args) do
+    children = [Gigex.Cache]
+
+    opts = [strategy: :one_for_one, name: Forecastr.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/lib/cache.ex
+++ b/lib/cache.ex
@@ -1,0 +1,55 @@
+defmodule Gigex.Cache do
+  @moduledoc """
+  Cache for sites that we scrape
+
+  The cache is cleaned up automatically after 2 hours.
+  """
+
+  @table_name :gigex_cache
+
+  use GenServer
+
+  @timer_interval :timer.hours(2)
+
+  @spec start_link(arg :: any()) :: :ignore | {:error, any} | {:ok, pid}
+  def start_link(_arg) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @spec get(key :: String.t()) :: content :: String.t()
+  def get(key) do
+    case :ets.lookup(@table_name, key) do
+      [{_key, content}] ->
+        content
+
+      [] ->
+        nil
+    end
+  end
+
+  def put(key, content) do
+    :ets.insert(@table_name, {key, content})
+    content
+  end
+
+  def init(_args) do
+    @table_name = :ets.new(@table_name, [:named_table, :public])
+
+    {:ok, %{ref: start_timer()}}
+  end
+
+  def handle_info(:cleanup, %{ref: ref}) do
+    :ets.delete_all_objects(@table_name)
+    new_ref = refresh_timer(ref)
+    {:noreply, %{ref: new_ref}}
+  end
+
+  defp start_timer() do
+    Process.send_after(self(), :cleanup, @timer_interval)
+  end
+
+  defp refresh_timer(ref) do
+    Process.cancel_timer(ref)
+    start_timer()
+  end
+end

--- a/lib/scraper/http.ex
+++ b/lib/scraper/http.ex
@@ -1,11 +1,6 @@
 defmodule Gigex.Scraper.HTTP do
   @spec get(url :: binary()) :: html :: binary()
   def get(url) do
-    # NOTE: Find out how to not hit too hard the website ;)
-    # Cache?
-    # For the moment `http_get/1` has a :timer.sleep of 200ms
-    :timer.sleep(200)
-
     HTTPoison.get!(url,
       user_agent: "Gigex (Windows x64)",
       timeout: 10_000

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,8 @@ defmodule Gigex.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      mod: {Gigex.Application, []}
     ]
   end
 


### PR DESCRIPTION
Introduces a cache for each scraper that caches the parsed content and cleans it up after two hours.